### PR TITLE
Add Origami Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Curators: Christopher, John and Moritz from [React Flow](https://reactflow.dev)
 - [Nodebox](https://github.com/nodebox/nodebox) - App for visualization and generative design [OSS]
 - [Nodes.io](https://nodes.io/) - Visual programming environment
 - [Nodetoy](https://nodetoy.co/) - Shader tool
+- [Origami Studio](https://origami.design/) - UI design prototyping tool
 - [Ossia score](https://github.com/ossia/score) - Sequencer for audio-visual artists [OSS]
 - [Polygonjs](https://github.com/polygonjs/polygonjs) - WebGL design tool [OSS]
 - [Protongraph](https://github.com/protongraph/protongraph) - Procedural content generation [OSS]


### PR DESCRIPTION
Origami Studio is a UI prototyping tool developed at Facebook. It's built (or was built) on top of Quartz Composer and has a patch/node UI for creating prototypes to be more accessible to designers.

Unsure if **3D & Visuals** is the right category for it, but it seemed like the best grouping I could find.